### PR TITLE
fix: split the expire and refresh cron jobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ parking_lot = "0.12"
 hashbrown = "0.13"
 tokio = { version = "1", features = ["sync", "time", "rt"] }
 async_singleflight = "0.5"
+dashmap = "5.5"
+ahash = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async_cache"
 version = "0.1.4"
-authors = ["Pure White <wudi@purewhite.io>"]
+authors = ["Pure White <wudi@purewhite.io>", "Giggle <wjdew@foxmail.com>"]
 edition = "2021"
 description = "Async refresh cache."
 repository = "https://github.com/PureWhiteWu/async_cache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_cache"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Pure White <wudi@purewhite.io>"]
 edition = "2021"
 description = "Async refresh cache."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 //! use async_cache::{AsyncCache, Fetcher, Options};
 //! use faststr::FastStr;
 //! use std::time::Duration;
-//! use dashmap::DashMap;
 //!
 //! #[derive(Clone)]
 //! struct MyValue(u32);
@@ -88,7 +87,6 @@ use std::sync::atomic;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ahash;
 use anyhow::Result;
 use async_singleflight::Group;
 use dashmap::DashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,8 +389,9 @@ where
 
             // second round, delete expired data
             for k in delete_keys {
-                let ety = data.remove(&k).unwrap();
-                self.send_delete(k, ety.val);
+                if let Some(ety) = data.remove(&k) {
+                    self.send_delete(k, ety.val);
+                }
             }
             drop(data);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,12 +173,12 @@ where
     pub fn build(self) -> AsyncCache<T, F> {
         let ac = AsyncCache {
             inner: Arc::new(AsyncCacheRef {
-                options: self,
                 sfg: Group::new(),
                 data: DashMap::with_capacity_and_hasher(
-                    DEFAULT_CACHE_CAPACITY,
+                    self.capacity,
                     ahash::RandomState::default(),
                 ),
+                options: self, // move options into AsyncCacheRef, so this should be the last line using self
             }),
         };
 
@@ -438,13 +438,5 @@ mod tests {
         let first_fetch = ac.get("123".into()).await;
         assert_eq!(first_fetch.unwrap(), 1);
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-    }
-
-    #[tokio::test]
-    async fn capacity_works() {
-        let ac = Options::new(std::time::Duration::from_secs(5), TestFetcher)
-            .with_capacity(10)
-            .build();
-        assert_eq!(ac.inner.data.capacity(), 10);
     }
 }


### PR DESCRIPTION
Motivation:
The expiration cron job was coupling with the refresh interval, so that it will lead to some incorrect behaviors.

Solution:
Use the `expire_interval` and specialized `expire_cron_job` to spilt the expiration and refresh logic. 